### PR TITLE
🐛 Invert the smoketest clause.

### DIFF
--- a/.github/workflows/docker-npm-branch.yml
+++ b/.github/workflows/docker-npm-branch.yml
@@ -50,7 +50,7 @@ jobs:
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-scan@v1
 
       - name: Publish branch image
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'smoketest') }}
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'smoketest') }}
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-publish@v1
         with:
           registry: ${{ inputs.registry }}


### PR DESCRIPTION
This was publishing when the label wasn't present and should have been when the label was present.