### PR TITLE
Update semver-tag-docker-gradle.yml

### DIFF
--- a/.github/workflows/semver-tag-docker-gradle.yml
+++ b/.github/workflows/semver-tag-docker-gradle.yml
@@ -24,6 +24,9 @@ jobs:
   docker:
     name: 'Main Semver Tag'
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'skip-release') == false
 
     steps:
       - name: Checkout repository
@@ -46,9 +49,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish main image
-        if: |
-          github.event.pull_request.merged == true &&
-          contains(github.event.pull_request.labels.*.name, 'skip-release') == false
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-publish@v1
         with:
           registry: ${{ inputs.registry }}


### PR DESCRIPTION
Move the if statement from the publish image step to the main job. This fixes a bug whereby a closed PR causes the GitHub Repo to be tagged incorrectly but no resulting build is created and pushed.