### PR TITLE
SASB-99: integrate ECR push into existent workflows

### DIFF
--- a/.github/workflows/anchore-gradle.yml
+++ b/.github/workflows/anchore-gradle.yml
@@ -15,6 +15,10 @@ on:
       image:
         required: true
         type: string
+      ecr:
+        required: true
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -43,12 +47,25 @@ jobs:
       - name: Anchore Scan image
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-scan@v2
 
-      - name: Publish image
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'smoketest') }}
+      - name: Publish image to Docker
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'smoketest') &&
+          inputs.ecr == false
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-publish@v2
         with:
           registry: ${{ inputs.registry }}
           username: ${{ secrets.DOCKER_USER_NAME || secrets.QUAY_ROBOT_USER_NAME }}
           password: ${{ secrets.DOCKER_PASSWORD || secrets.QUAY_ROBOT_TOKEN }}
+          tag: ${{ github.event.pull_request.head.sha }}
+          image: ${{ inputs.image }}
+
+      - name: Publish image to ECR
+        uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-ecr-publish@v1
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'smoketest') &&
+          inputs.ecr == true
+        with:
+          access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tag: ${{ github.event.pull_request.head.sha }}
           image: ${{ inputs.image }}

--- a/.github/workflows/anchore-npm.yml
+++ b/.github/workflows/anchore-npm.yml
@@ -21,6 +21,10 @@ on:
       image:
         required: true
         type: string
+      ecr:
+        required: true
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -49,12 +53,25 @@ jobs:
       - name: Anchore Scan image
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-scan@v2
 
-      - name: Publish image
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'smoketest') }}
+      - name: Publish image to Docker
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'smoketest') &&
+          inputs.ecr == false
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-publish@v2
         with:
           registry: ${{ inputs.registry }}
           username: ${{ secrets.DOCKER_USER_NAME || secrets.QUAY_ROBOT_USER_NAME }}
           password: ${{ secrets.DOCKER_PASSWORD || secrets.QUAY_ROBOT_TOKEN }}
+          tag: ${{ github.event.pull_request.head.sha }}
+          image: ${{ inputs.image }}
+
+      - name: Publish image to ECR
+        uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-ecr-publish@v1
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'smoketest') &&
+          inputs.ecr == true
+        with:
+          access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tag: ${{ github.event.pull_request.head.sha }}
           image: ${{ inputs.image }}

--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -8,6 +8,10 @@ on:
       image:
         required: true
         type: string
+      ecr:
+        required: true
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,12 +33,25 @@ jobs:
       - name: Anchore Scan image
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-scan@v2
 
-      - name: Publish image
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'smoketest') }}
+      - name: Publish image to Docker
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'smoketest') &&
+          inputs.ecr == false
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-publish@v2
         with:
           registry: ${{ inputs.registry }}
           username: ${{ secrets.DOCKER_USER_NAME || secrets.QUAY_ROBOT_USER_NAME }}
           password: ${{ secrets.DOCKER_PASSWORD || secrets.QUAY_ROBOT_TOKEN }}
+          tag: ${{ github.event.pull_request.head.sha }}
+          image: ${{ inputs.image }}
+
+      - name: Publish image to ECR
+        uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-ecr-publish@v1
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'smoketest') &&
+          inputs.ecr == true
+        with:
+          access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tag: ${{ github.event.pull_request.head.sha }}
           image: ${{ inputs.image }}

--- a/.github/workflows/semver-tag-docker-gradle.yml
+++ b/.github/workflows/semver-tag-docker-gradle.yml
@@ -15,6 +15,10 @@ on:
       image:
         required: true
         type: string
+      ecr:
+        required: true
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}
@@ -48,8 +52,19 @@ jobs:
           build_command: ${{ inputs.buildCommand }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish main image
+      - name: Publish image to ECR
+        uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-ecr-publish@v2
+        if: inputs.ecr == true
+        with:
+          access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          tag: ${{ steps.calculate.outputs.version }}
+          tag_latest: ${{ github.base_ref == 'main' }}
+          image: ${{ inputs.image }}
+
+      - name: Publish image to Docker
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-publish@v2
+        if: inputs.ecr == false
         with:
           registry: ${{ inputs.registry }}
           username: ${{ secrets.DOCKER_USER_NAME || secrets.QUAY_ROBOT_USER_NAME }}

--- a/.github/workflows/semver-tag-docker-npm.yml
+++ b/.github/workflows/semver-tag-docker-npm.yml
@@ -21,6 +21,10 @@ on:
       image:
         required: true
         type: string
+      ecr:
+        required: true
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}
@@ -30,6 +34,9 @@ jobs:
   docker:
     name: 'Main Semver Tag'
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'skip-release') == false
 
     steps:
       - name: Checkout repository
@@ -51,11 +58,19 @@ jobs:
           install_command: ${{ inputs.installCommand }}
           build_command: ${{ inputs.buildCommand }}
 
-      - name: Publish main image
-        if: |
-          github.event.pull_request.merged == true &&
-          contains(github.event.pull_request.labels.*.name, 'skip-release') == false
+      - name: Publish image to ECR
+        uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-ecr-publish@v2
+        if: inputs.ecr == true
+        with:
+          access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          tag: ${{ steps.calculate.outputs.version }}
+          tag_latest: ${{ github.base_ref == 'main' }}
+          image: ${{ inputs.image }}
+
+      - name: Publish image to Docker
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-publish@v2
+        if: inputs.ecr == false
         with:
           registry: ${{ inputs.registry }}
           username: ${{ secrets.DOCKER_USER_NAME || secrets.QUAY_ROBOT_USER_NAME }}

--- a/.github/workflows/semver-tag-docker.yml
+++ b/.github/workflows/semver-tag-docker.yml
@@ -8,6 +8,10 @@ on:
       image:
         required: true
         type: string
+      ecr:
+        required: true
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}
@@ -17,6 +21,9 @@ jobs:
   docker:
     name: 'Main Semver Tag'
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'skip-release') == false
 
     steps:
       - name: Checkout repository
@@ -31,11 +38,19 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_to_highest: ${{ github.base_ref == 'main' }}
 
-      - name: Publish main image
-        if: |
-          github.event.pull_request.merged == true &&
-          contains(github.event.pull_request.labels.*.name, 'skip-release') == false
+      - name: Publish image to ECR
+        uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-ecr-publish@v2
+        if: inputs.ecr == true
+        with:
+          access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          tag: ${{ steps.calculate.outputs.version }}
+          tag_latest: ${{ github.base_ref == 'main' }}
+          image: ${{ inputs.image }}
+
+      - name: Publish image to Docker
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-publish@v2
+        if: inputs.ecr == false
         with:
           registry: ${{ inputs.registry }}
           username: ${{ secrets.DOCKER_USER_NAME || secrets.QUAY_ROBOT_USER_NAME }}

--- a/README.md
+++ b/README.md
@@ -25,12 +25,19 @@ jobs:
 
 ## Scan a docker image using Anchore
 
-This workflow builds and scans a docker image using Anchore.
-Optionally it pushes the image to a repository, tagging it with the SHA.
+This workflow builds and scans a docker image using Anchore, optionally, pushing to a repository with the SHA.
 
-* Needs a secret value of DOCKER_USER_NAME or QUAY_ROBOT_USER_NAME
-* Needs a secret value of DOCKER_PASSWORD or QUAY_ROBOT_TOKEN
-* Will only push with a label of `smoketest`
+When the `smoketest` of label is applied, the image will be pushed to either Docker (default) or ECR.
+
+**ECR**
+* Requires secret value of `AWS_ACCESS_KEY_ID`
+* Requires secret value of `AWS_SECRET_ACCESS_KEY`
+
+**Docker**
+* Requires secret value of `DOCKER_USER_NAME` or `QUAY_ROBOT_USER_NAME`
+* Requires secret value of `DOCKER_PASSWORD` or `QUAY_ROBOT_TOKEN`
+
+To push to `ECR`, an addition input is required within the with: `ecr: 'true'`.
 
 ### anchore.yml
 
@@ -57,12 +64,19 @@ jobs:
 
 ## Scan a docker image using Anchore - gradle
 
-This workflow builds and scans a docker image using Anchore.
-Optionally it pushes the image to a repository, tagging it with the SHA.
+This workflow builds and scans a docker image using Anchore, optionally, pushing to a repository with the SHA.
 
-* Needs a secret value of DOCKER_USER_NAME or QUAY_ROBOT_USER_NAME
-* Needs a secret value of DOCKER_PASSWORD or QUAY_ROBOT_TOKEN
-* Will only push with a label of `smoketest`
+When the `smoketest` of label is applied, the image will be pushed to either Docker (default) or ECR.
+
+**ECR**
+* Requires secret value of `AWS_ACCESS_KEY_ID`
+* Requires secret value of `AWS_SECRET_ACCESS_KEY`
+
+**Docker**
+* Requires secret value of `DOCKER_USER_NAME` or `QUAY_ROBOT_USER_NAME`
+* Requires secret value of `DOCKER_PASSWORD` or `QUAY_ROBOT_TOKEN`
+
+To push to `ECR`, an addition input is required within the with: `ecr: 'true'`.
 
 ### anchore-gradle.yml
 
@@ -89,12 +103,19 @@ jobs:
 
 ## Scan a docker image using Anchore - npm
 
-This workflow builds and scans a docker image using Anchore. 
-Optionally it pushes the image to a repository, tagging it with the SHA.
+This workflow builds and scans a docker image using Anchore, optionally, pushing to a repository with the SHA.
 
-* Needs a secret value of DOCKER_USER_NAME or QUAY_ROBOT_USER_NAME
-* Needs a secret value of DOCKER_PASSWORD or QUAY_ROBOT_TOKEN
-* Will only push with a label of `smoketest`
+When the `smoketest` of label is applied, the image will be pushed to either Docker (default) or ECR.
+
+**ECR**
+* Requires secret value of `AWS_ACCESS_KEY_ID`
+* Requires secret value of `AWS_SECRET_ACCESS_KEY`
+
+**Docker**
+* Requires secret value of `DOCKER_USER_NAME` or `QUAY_ROBOT_USER_NAME`
+* Requires secret value of `DOCKER_PASSWORD` or `QUAY_ROBOT_TOKEN`
+
+To push to `ECR`, an addition input is required within the with: `ecr: 'true'`.
 
 ### anchore-npm.yml
 
@@ -240,10 +261,17 @@ jobs:
 
 ## Publish a docker image
 
-This workflow builds and publishes a docker image with a SemVer value.
+This workflow builds and publishes a docker image to either Docker (default) or ECR with a SemVer value.
 
-* Needs a secret value of DOCKER_USER_NAME or QUAY_ROBOT_USER_NAME
-* Needs a secret value of DOCKER_PASSWORD or QUAY_ROBOT_TOKEN
+**ECR**
+* Requires secret value of `AWS_ACCESS_KEY_ID`
+* Requires secret value of `AWS_SECRET_ACCESS_KEY`
+
+**Docker**
+* Requires secret value of `DOCKER_USER_NAME` or `QUAY_ROBOT_USER_NAME`
+* Requires secret value of `DOCKER_PASSWORD` or `QUAY_ROBOT_TOKEN`
+
+To push to `ECR`, an addition input is required within the with: `ecr: 'true'`.
 
 ### semver-tag-docker.yml
 
@@ -266,10 +294,17 @@ jobs:
 
 ## Publish a docker image - gradle
 
-This workflow builds and publishes a docker image with a SemVer value.
+This workflow builds and publishes a docker image to either Docker (default) or ECR with a SemVer value.
 
-* Needs a secret value of DOCKER_USER_NAME or QUAY_ROBOT_USER_NAME
-* Needs a secret value of DOCKER_PASSWORD or QUAY_ROBOT_TOKEN
+**ECR**
+* Requires secret value of `AWS_ACCESS_KEY_ID`
+* Requires secret value of `AWS_SECRET_ACCESS_KEY`
+
+**Docker**
+* Requires secret value of `DOCKER_USER_NAME` or `QUAY_ROBOT_USER_NAME`
+* Requires secret value of `DOCKER_PASSWORD` or `QUAY_ROBOT_TOKEN`
+
+To push to `ECR`, an addition input is required within the with: `ecr: 'true'`.
 
 ### semver-tag-docker-gradle.yml
 
@@ -292,10 +327,17 @@ jobs:
 
 ## Publish a docker image - npm
 
-This workflow builds and publishes a docker image with a SemVer value.
+This workflow builds and publishes a docker image to either Docker (default) or ECR with a SemVer value.
 
-* Needs a secret value of DOCKER_USER_NAME or QUAY_ROBOT_USER_NAME
-* Needs a secret value of DOCKER_PASSWORD or QUAY_ROBOT_TOKEN
+**ECR**
+* Requires secret value of `AWS_ACCESS_KEY_ID`
+* Requires secret value of `AWS_SECRET_ACCESS_KEY`
+
+**Docker**
+* Requires secret value of `DOCKER_USER_NAME` or `QUAY_ROBOT_USER_NAME`
+* Requires secret value of `DOCKER_PASSWORD` or `QUAY_ROBOT_TOKEN`
+
+To push to `ECR`, an addition input is required within the with: `ecr: 'true'`.
 
 ### semver-tag-docker-npm.yml
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
 
 This workflow builds and scans a docker image using Anchore, optionally, pushing to a repository with the SHA.
 
-When the `smoketest` of label is applied, the image will be pushed to either Docker (default) or ECR.
+When the `smoketest` label is applied, the image will be pushed to either Docker (default) or ECR.
 
 **ECR**
 * Requires secret value of `AWS_ACCESS_KEY_ID`
@@ -66,7 +66,7 @@ jobs:
 
 This workflow builds and scans a docker image using Anchore, optionally, pushing to a repository with the SHA.
 
-When the `smoketest` of label is applied, the image will be pushed to either Docker (default) or ECR.
+When the `smoketest` label is applied, the image will be pushed to either Docker (default) or ECR.
 
 **ECR**
 * Requires secret value of `AWS_ACCESS_KEY_ID`
@@ -105,7 +105,7 @@ jobs:
 
 This workflow builds and scans a docker image using Anchore, optionally, pushing to a repository with the SHA.
 
-When the `smoketest` of label is applied, the image will be pushed to either Docker (default) or ECR.
+When the `smoketest` label is applied, the image will be pushed to either Docker (default) or ECR.
 
 **ECR**
 * Requires secret value of `AWS_ACCESS_KEY_ID`


### PR DESCRIPTION
The workflows previously only supported pushing into a `public` docker registry. With the addition of the docker-ecr-push action, the existing workflows can support the ECR push.

This is turned off by default, to preserve backwards compatibility, and requires the access key and secret key to be provided within the callee repository secrets.