### PR TITLE
SASB-124: add actions to support Trivy scanning

### DIFF
--- a/.github/actions/trivy-image-scan/action.yml
+++ b/.github/actions/trivy-image-scan/action.yml
@@ -1,0 +1,40 @@
+name: 'Trivy Scan Docker Image'
+description: 'Builds and scans a docker image using Trivy'
+inputs:
+  sarif:
+    required: true
+    description: 'Whether to generate a sarif report, otherwise a table is generated'
+  severity:
+    required: true
+    description: 'The severity of the vulnerabilities to report.'
+    
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build image
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        tags: localbuild/testimage:latest
+        load: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@0.11.2
+      with:
+        image-ref: 'localbuild/testimage:latest'
+        ignore-unfixed: true
+        format: ${{ inputs.sarif == 'true' && 'sarif' || 'table' }} 
+        output: ${{ inputs.sarif == 'true' && 'trivy-results.sarif' || '' }}
+        severity: ${{ inputs.severity }}
+        exit-code: '1'
+        
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v2
+      if: inputs.sarif == 'true'
+      with:
+        sarif_file: 'trivy-results.sarif'

--- a/.github/actions/trivy-repo-scan/action.yml
+++ b/.github/actions/trivy-repo-scan/action.yml
@@ -1,0 +1,28 @@
+name: 'Trivy Scan Repository'
+description: 'Scans repository using Trivy'
+inputs:
+  sarif:
+    required: true
+    description: 'Whether to generate a sarif report, otherwise a table is generated.'
+  severity:
+    required: true
+    description: 'The severity of the vulnerabilities to report.'
+    
+runs:
+  using: 'composite'
+  steps:
+    - name: Run Trivy vulnerability scanner in repo mode
+      uses: aquasecurity/trivy-action@0.11.2
+      with:
+        scan-type: 'fs'
+        ignore-unfixed: true
+        format: ${{ inputs.sarif == 'true' && 'sarif' || 'table' }}
+        output: ${{ inputs.sarif == 'true' && 'trivy-results.sarif' || '' }}
+        severity: ${{ inputs.severity }}
+        exit-code: '1'
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v2
+      if: inputs.sarif == 'true'
+      with:
+        sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,45 @@
+name: 'Trivy Scan Docker and Repository'
+on:
+  workflow_call:
+    inputs:
+      sarif:
+        required: true
+        description: 'Whether to generate a sarif report, otherwise a table is generated.'
+        type: string
+        default: 'false'
+      severity:
+        required: true
+        description: 'The severity of the vulnerabilities to report.'
+        type: string
+        default: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  image:
+    name: 'Trivy Image Scan'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Scan image
+        uses: UKHomeOffice/sas-github-workflows/.github/actions/trivy-image-scan@v2
+        with: 
+          sarif: ${{ inputs.sarif }}
+          severity: ${{ inputs.severity }}
+  
+  repo:
+    name: 'Trivy Repo Scan'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Scan repository 
+        uses: UKHomeOffice/sas-github-workflows/.github/actions/trivy-repo-scan@v2
+        with:
+          sarif: ${{ inputs.sarif }}
+          severity: ${{ inputs.severity }}


### PR DESCRIPTION
This change add a Trivy workflow that can be run from other projects. This underlying utilises 2 actions for image scanning and repo scanning.