### PR TITLE
SASB-124: add missing checkout step for image scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -25,6 +25,11 @@ jobs:
       security-events: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          
       - name: Scan image
         uses: UKHomeOffice/sas-github-workflows/.github/actions/trivy-image-scan@v2
         with: 


### PR DESCRIPTION
This change adds a missing checkout step for the image scan, this is required to have the Dockerfile present to build.