### PR TITLE
SASB-124: add checkout and permission to workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -43,6 +43,11 @@ jobs:
       security-events: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          
       - name: Scan repository 
         uses: UKHomeOffice/sas-github-workflows/.github/actions/trivy-repo-scan@v2
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -22,6 +22,7 @@ jobs:
     name: 'Trivy Image Scan'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
 
     steps:
@@ -40,6 +41,7 @@ jobs:
     name: 'Trivy Repo Scan'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
 
     steps:


### PR DESCRIPTION
The permissions override removes the -apparently- default contents read permission. This change add this back in, that should allow it to checkout the private repository.

https://github.com/actions/checkout/issues/254#issuecomment-1632353441

This change also adds a missing checkout for the repo scan.