### PR TITLE
Remove `required` on `ecr` input

### DIFF
--- a/.github/workflows/anchore-gradle.yml
+++ b/.github/workflows/anchore-gradle.yml
@@ -16,7 +16,6 @@ on:
         required: true
         type: string
       ecr:
-        required: true
         type: boolean
         default: false
 

--- a/.github/workflows/anchore-npm.yml
+++ b/.github/workflows/anchore-npm.yml
@@ -22,7 +22,6 @@ on:
         required: true
         type: string
       ecr:
-        required: true
         type: boolean
         default: false
 

--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -9,7 +9,6 @@ on:
         required: true
         type: string
       ecr:
-        required: true
         type: boolean
         default: false
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -12,7 +12,6 @@ on:
         required: true
         type: string
       ecr:
-        required: true
         type: boolean
         default: false
 

--- a/.github/workflows/semver-tag-docker-gradle.yml
+++ b/.github/workflows/semver-tag-docker-gradle.yml
@@ -16,7 +16,6 @@ on:
         required: true
         type: string
       ecr:
-        required: true
         type: boolean
         default: false
 

--- a/.github/workflows/semver-tag-docker-npm.yml
+++ b/.github/workflows/semver-tag-docker-npm.yml
@@ -22,7 +22,6 @@ on:
         required: true
         type: string
       ecr:
-        required: true
         type: boolean
         default: false
 

--- a/.github/workflows/semver-tag-docker.yml
+++ b/.github/workflows/semver-tag-docker.yml
@@ -9,7 +9,6 @@ on:
         required: true
         type: string
       ecr:
-        required: true
         type: boolean
         default: false
 


### PR DESCRIPTION
A breaking change between with the introduction of the `ecr` property meant that callees had to specify `ecr: false` even if the default was present. This change removes the `required` which allows the default to take effect without having the callee have to change their implementation.