### PR TITLE
Add generic build and tag workflow

### DIFF
--- a/.github/workflows/tag-docker.yml
+++ b/.github/workflows/tag-docker.yml
@@ -1,0 +1,58 @@
+name: 'Build Docker and Tag Repository'
+on:
+  workflow_call:
+    inputs:
+      registry:
+        required: false
+        type: string
+      image:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+      ecr:
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  docker:
+    name: 'Build Docker and Tag Repository'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Publish image to ECR
+        uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-ecr-publish@v2
+        if: inputs.ecr == true
+        with:
+          access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          tag: ${{ steps.calculate.outputs.version }}
+          tag_latest: ${{ github.base_ref == 'main' }}
+          image: ${{ inputs.image }}
+
+      - name: Publish image to Docker
+        uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-publish@v2
+        if: inputs.ecr == false
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ secrets.DOCKER_USER_NAME || secrets.QUAY_ROBOT_USER_NAME }}
+          password: ${{ secrets.DOCKER_PASSWORD || secrets.QUAY_ROBOT_TOKEN }}
+          tag: ${{ steps.calculate.outputs.version }}
+          tag_latest: ${{ github.base_ref == 'main' }}
+          image: ${{ inputs.image }}
+
+      - name: Tag Repository
+        uses: UKHomeOffice/semver-tag-action@v3
+        with:
+          tag: ${{ inputs.tag }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -293,6 +293,41 @@ jobs:
 
 ----
 
+## Publish a docker image with arbitrary version
+
+This workflow builds and publishes a docker image to either Docker (default) or ECR with an arbitrary value. This 
+arbitrary version is a required input into the workflow 
+
+**ECR**
+* Requires secret value of `AWS_ACCESS_KEY_ID`
+* Requires secret value of `AWS_SECRET_ACCESS_KEY`
+
+**Docker**
+* Requires secret value of `DOCKER_USER_NAME` or `QUAY_ROBOT_USER_NAME`
+* Requires secret value of `DOCKER_PASSWORD` or `QUAY_ROBOT_TOKEN`
+
+To push to `ECR`, an addition input is required within the with: `ecr: 'true'`.
+
+### semver-tag-docker.yml
+
+```yaml
+name: 'Build Docker and Tag Repository'
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  build:
+    uses: UKHomeOffice/sas-github-workflows/.github/workflows/tag-docker.yml@v2
+    with:
+      image: 'quay.io/ukhomeofficedigital/hocs-toolbox'
+      tag: ${{ github.sha }}
+    secrets: inherit
+
+```
+
+----
+
 ## Publish a docker image with SemVer version
 
 This workflow builds and publishes a docker image to either Docker (default) or ECR with a SemVer value.


### PR DESCRIPTION
This change adds a workflow that allows for a generic docker build and tag. This effectively pulls the SemVer calculation out the existent solutions to support repositories that don't need SemVer.