### PR TITLE
Make submodule checkout optional

### DIFF
--- a/.github/workflows/actions-check-dist.yml
+++ b/.github/workflows/actions-check-dist.yml
@@ -15,6 +15,11 @@ on:
       lintCommand:
         required: false
         type: string
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +38,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
 
       - name: Build project
         uses: UKHomeOffice/sas-github-workflows/.github/actions/npm-build-project@v2

--- a/.github/workflows/anchore-gradle.yml
+++ b/.github/workflows/anchore-gradle.yml
@@ -18,6 +18,11 @@ on:
       ecr:
         type: boolean
         default: false
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -34,7 +39,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
 
       - name: Build project
         uses: UKHomeOffice/sas-github-workflows/.github/actions/gradle-build-project@v2

--- a/.github/workflows/anchore-npm.yml
+++ b/.github/workflows/anchore-npm.yml
@@ -24,6 +24,11 @@ on:
       ecr:
         type: boolean
         default: false
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -40,7 +45,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
 
       - name: Build project
         uses: UKHomeOffice/sas-github-workflows/.github/actions/npm-build-project@v2

--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -11,6 +11,11 @@ on:
       ecr:
         type: boolean
         default: false
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,7 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
 
       - name: Anchore Scan image
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-scan@v2

--- a/.github/workflows/codeql-analysis-gradle.yml
+++ b/.github/workflows/codeql-analysis-gradle.yml
@@ -9,6 +9,11 @@ on:
       buildCommand:
         required: false
         type: string
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,7 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql-analysis-npm.yml
+++ b/.github/workflows/codeql-analysis-npm.yml
@@ -1,6 +1,12 @@
 name: 'CodeQL - npm'
 on:
   workflow_call:
+    inputs:
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,7 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql-analysis-pip.yml
+++ b/.github/workflows/codeql-analysis-pip.yml
@@ -1,6 +1,12 @@
 name: "CodeQL - pip"
 on:
   workflow_call:
+    inputs:
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,7 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -14,6 +14,11 @@ on:
       ecr:
         type: boolean
         default: false
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}
@@ -31,7 +36,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
 
       - name: Publish image to ECR
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-ecr-publish@v2

--- a/.github/workflows/semver-tag-docker-gradle.yml
+++ b/.github/workflows/semver-tag-docker-gradle.yml
@@ -18,6 +18,11 @@ on:
       ecr:
         type: boolean
         default: false
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}
@@ -35,7 +40,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
 
       - name: Calculate SemVer value
         id: calculate

--- a/.github/workflows/semver-tag-docker-npm.yml
+++ b/.github/workflows/semver-tag-docker-npm.yml
@@ -24,6 +24,11 @@ on:
       ecr:
         type: boolean
         default: false
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}
@@ -41,7 +46,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
 
       - name: Calculate SemVer value
         id: calculate

--- a/.github/workflows/semver-tag-docker.yml
+++ b/.github/workflows/semver-tag-docker.yml
@@ -11,6 +11,11 @@ on:
       ecr:
         type: boolean
         default: false
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}
@@ -28,7 +33,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
 
       - name: Calculate SemVer value
         id: calculate

--- a/.github/workflows/tag-docker.yml
+++ b/.github/workflows/tag-docker.yml
@@ -17,6 +17,11 @@ on:
       ecr:
         type: boolean
         default: false
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}
@@ -31,7 +36,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
 
       - name: Publish image to ECR
         uses: UKHomeOffice/sas-github-workflows/.github/actions/docker-ecr-publish@v2

--- a/.github/workflows/test-gradle.yml
+++ b/.github/workflows/test-gradle.yml
@@ -24,6 +24,11 @@ on:
       healthcheckScript:
         required: false
         type: string
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -38,7 +43,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
 
       - name: Build project
         uses: UKHomeOffice/sas-github-workflows/.github/actions/gradle-build-project@v2

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -33,6 +33,11 @@ on:
       healthcheckScript:
         required: false
         type: string
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -51,7 +56,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
 
       - name: Build project
         uses: UKHomeOffice/sas-github-workflows/.github/actions/npm-build-project@v2

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       sarif:
-        required: true
+        required: false
         description: 'Whether to generate a sarif report, otherwise a table is generated.'
         type: string
         default: 'false'
@@ -12,6 +12,11 @@ on:
         description: 'The severity of the vulnerabilities to report.'
         type: string
         default: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+      checkoutSubmodule:
+        required: false
+        description: 'Whether to checkout submodules.'
+        type: string
+        default: 'true'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,7 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
           
       - name: Scan image
         uses: UKHomeOffice/sas-github-workflows/.github/actions/trivy-image-scan@v2
@@ -48,7 +53,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.checkoutSubmodule }}
           
       - name: Scan repository 
         uses: UKHomeOffice/sas-github-workflows/.github/actions/trivy-repo-scan@v2


### PR DESCRIPTION
This change adds a boolean flag to enable the checking out of submodules if applicable. To maintain backwards compatibility, this is set to default `true`. Future work should endeavour to remove all the checkout steps and pass that responsibility onto the callee due to the number of repo specific checkout options are possible.